### PR TITLE
Fixed class name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $display = VKOAuthDisplay::PAGE;
 $scope = array(VKOAuthUserScope::WALL, VKOAuthUserScope::GROUPS);
 $state = 'secret_state_code';
 
-$browser_url = $oauth->getAuthorizeUrl(OAuthResponseType::CODE, $client_id, $redirect_uri, $display, $scope, $state);
+$browser_url = $oauth->getAuthorizeUrl(VKOAuthResponseType::CODE, $client_id, $redirect_uri, $display, $scope, $state);
 ```
 #### 4.1.2. Or if you want to get **community access key** use:
 ```php


### PR DESCRIPTION
There was a typo in README (**OAuthResponseType** instead of **VKOAuthResponseType**).